### PR TITLE
gstreamer: Fix compilation

### DIFF
--- a/src/Backends/Banshee.GStreamerSharp/Banshee.GStreamerSharp/VideoManager.cs
+++ b/src/Backends/Banshee.GStreamerSharp/Banshee.GStreamerSharp/VideoManager.cs
@@ -54,7 +54,7 @@ namespace Banshee.GStreamerSharp
         Element playbin;
         VideoDisplayContextType video_display_context_type;
         IntPtr video_window;
-        ulong? video_window_xid;
+        IntPtr? video_window_xid;
         VideoOverlayAdapter xoverlay;
         object video_mutex = new object ();
 
@@ -299,13 +299,13 @@ namespace Banshee.GStreamerSharp
             switch (System.Environment.OSVersion.Platform) {
                 case PlatformID.Unix:
                     //FIXME: we should maybe stop relying on x11 http://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-base-libs/html/gst-plugins-base-libs-gstvideooverlay.html#GstVideoOverlay
-                    video_window_xid = (ulong)gdk_x11_window_get_xid (window);
+                    video_window_xid = gdk_x11_window_get_xid (window);
                 break;
                 case PlatformID.Win32NT:
                 case PlatformID.Win32S:
                 case PlatformID.Win32Windows:
                 case PlatformID.WinCE:
-                    video_window_xid = (ulong)gdk_win32_drawable_get_handle (window);
+                    video_window_xid = gdk_win32_drawable_get_handle (window);
                 break;
             }
         }


### PR DESCRIPTION
The compile was broken due to some implicit ulong -> IntPtr conversions.
Just use IntPtr throughout since it is actually a pointer.