### PR TITLE
gstreamer: Fix a crash when video couldn't be played

### DIFF
--- a/src/Backends/Banshee.GStreamer/Banshee.GStreamer/PlayerEngine.cs
+++ b/src/Backends/Banshee.GStreamer/Banshee.GStreamer/PlayerEngine.cs
@@ -453,7 +453,7 @@ namespace Banshee.GStreamer
             //
             // This will be overridden by IncrementLastPlayed () called by
             // PlaybackControllerService's EndOfStream handler.
-            CurrentTrack.UpdateLastPlayed ();
+            CurrentTrack?.UpdateLastPlayed ();
 
             next_track_set.Reset ();
             pending_uri = null;

--- a/src/Backends/Banshee.GStreamerSharp/Banshee.GStreamerSharp/PlayerEngine.cs
+++ b/src/Backends/Banshee.GStreamerSharp/Banshee.GStreamerSharp/PlayerEngine.cs
@@ -419,7 +419,7 @@ namespace Banshee.GStreamerSharp
             //
             // This will be overridden by IncrementLastPlayed () called by
             // PlaybackControllerService's EndOfStream handler.
-            CurrentTrack.UpdateLastPlayed ();
+            CurrentTrack?.UpdateLastPlayed ();
 
             next_track_set.Reset ();
             pending_uri = null;


### PR DESCRIPTION
If the gstreamer lib isn't able to play the video it might happen that
CurrentTrack is null. Check for null otherwise an NRE might be thrown.

Closes #3